### PR TITLE
Add animated bilingual portfolio site

### DIFF
--- a/crazy-portfolio/index.html
+++ b/crazy-portfolio/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Moaz – Programmer & Marketing Manager</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&family=Cairo:wght@300;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <header>
+        <nav class="container">
+            <div class="logo" data-i18n="logo">Moaz</div>
+            <ul class="nav-links">
+                <li><a href="#about" data-i18n="nav.about">About</a></li>
+                <li><a href="#certificates" data-i18n="nav.certificates">Certificates</a></li>
+                <li><a href="#projects" data-i18n="nav.projects">Projects</a></li>
+                <li><a href="#contact" data-i18n="nav.contact">Contact</a></li>
+            </ul>
+            <button id="lang-toggle">AR</button>
+        </nav>
+    </header>
+
+    <section class="hero container">
+        <h1 data-i18n="hero.title">Hi, I'm Moaz</h1>
+        <p data-i18n="hero.subtitle">Developer & Marketing Manager</p>
+        <div class="shapes">
+            <div class="shape"></div>
+            <div class="shape"></div>
+            <div class="shape"></div>
+        </div>
+    </section>
+
+    <section id="about" class="section container">
+        <h2 data-i18n="about.title">About Me</h2>
+        <p data-i18n="about.body">I craft digital experiences that merge code with compelling marketing.</p>
+    </section>
+
+    <section id="certificates" class="section container">
+        <h2 data-i18n="cert.title">Certificates</h2>
+        <ul class="cards">
+            <li data-i18n="cert.item1">Google Marketing Certification</li>
+            <li data-i18n="cert.item2">Full‑Stack Web Development</li>
+        </ul>
+    </section>
+
+    <section id="projects" class="section container">
+        <h2 data-i18n="projects.title">Projects</h2>
+        <ul class="cards">
+            <li data-i18n="projects.item1">E‑commerce Platform</li>
+            <li data-i18n="projects.item2">Social Media Analytics Tool</li>
+        </ul>
+    </section>
+
+    <section id="contact" class="section container">
+        <h2 data-i18n="contact.title">Get in Touch</h2>
+        <p data-i18n="contact.body">Email: moaz@example.com</p>
+    </section>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" integrity="sha512-D44tTqbFhH0uB4JWS3ZKRyhOZLfjtUPZEcXpUZLFSCdE2tzsqnZOPd8AVtxzhfnDRpzj8aZNvYVTm160Y99qFA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/crazy-portfolio/script.js
+++ b/crazy-portfolio/script.js
@@ -1,0 +1,50 @@
+const translations = {
+  en: {
+    logo: "Moaz",
+    nav: {about: "About", certificates: "Certificates", projects: "Projects", contact: "Contact"},
+    hero: {title: "Hi, I'm Moaz", subtitle: "Developer & Marketing Manager"},
+    about: {title: "About Me", body: "I craft digital experiences that merge code with compelling marketing."},
+    cert: {title: "Certificates", item1: "Google Marketing Certification", item2: "Full‑Stack Web Development"},
+    projects: {title: "Projects", item1: "E‑commerce Platform", item2: "Social Media Analytics Tool"},
+    contact: {title: "Get in Touch", body: "Email: moaz@example.com"}
+  },
+  ar: {
+    logo: "معاذ",
+    nav: {about: "من أنا", certificates: "الشهادات", projects: "الأعمال", contact: "تواصل"},
+    hero: {title: "مرحباً، أنا معاذ", subtitle: "مبرمج ومدير تسويق"},
+    about: {title: "نبذة عني", body: "أصنع تجارب رقمية تمزج بين البرمجة والتسويق المبدع."},
+    cert: {title: "الشهادات", item1: "شهادة جوجل للتسويق", item2: "تطوير ويب متكامل"},
+    projects: {title: "الأعمال", item1: "منصة تجارة إلكترونية", item2: "أداة تحليل وسائل التواصل"},
+    contact: {title: "تواصل معي", body: "البريد: moaz@example.com"}
+  }
+};
+
+let currentLang = 'en';
+const toggleBtn = document.getElementById('lang-toggle');
+
+function setLanguage(lang) {
+  currentLang = lang;
+  document.documentElement.lang = lang;
+  document.body.setAttribute('dir', lang === 'ar' ? 'rtl' : 'ltr');
+  toggleBtn.textContent = lang === 'ar' ? 'EN' : 'AR';
+
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const keys = el.getAttribute('data-i18n').split('.');
+    let text = translations[lang];
+    keys.forEach(k => { text = text[k]; });
+    if (text) el.textContent = text;
+  });
+}
+
+toggleBtn.addEventListener('click', () => {
+  setLanguage(currentLang === 'en' ? 'ar' : 'en');
+});
+
+setLanguage(currentLang);
+
+// Animations
+window.addEventListener('load', () => {
+  gsap.from('.hero h1', {y: 50, opacity: 0, duration: 1});
+  gsap.from('.hero p', {y: 50, opacity: 0, duration: 1, delay: 0.3});
+  gsap.to('.shape', {y: -20, repeat: -1, yoyo: true, duration: 3, ease: 'sine.inOut'});
+});

--- a/crazy-portfolio/style.css
+++ b/crazy-portfolio/style.css
@@ -1,0 +1,139 @@
+/* Base styles */
+:root {
+  --accent: #ff006e;
+  --bg: #0d0d0d;
+  --text: #f0f0f0;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Poppins', 'Cairo', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+.container {
+  width: 90%;
+  max-width: 1100px;
+  margin: auto;
+}
+
+header {
+  padding: 20px 0;
+}
+
+nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.5rem;
+  color: var(--accent);
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 20px;
+}
+
+.nav-links a {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 500;
+  position: relative;
+}
+
+.nav-links a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  width: 0;
+  height: 2px;
+  background: var(--accent);
+  transition: width .3s;
+}
+
+.nav-links a:hover::after {
+  width: 100%;
+}
+
+#lang-toggle {
+  background: var(--accent);
+  border: none;
+  color: #fff;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.hero {
+  text-align: center;
+  padding: 100px 0;
+  position: relative;
+}
+
+.shapes {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  z-index: -1;
+}
+
+.shape {
+  position: absolute;
+  width: 60px;
+  height: 60px;
+  background: var(--accent);
+  opacity: 0.6;
+  border-radius: 50%;
+  animation: float 6s infinite ease-in-out;
+}
+
+.shape:nth-child(1) { top: 10%; left: 20%; }
+.shape:nth-child(2) { top: 50%; left: 70%; animation-duration: 8s; }
+.shape:nth-child(3) { top: 80%; left: 10%; animation-duration: 10s; }
+
+@keyframes float {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-40px) scale(1.2); }
+}
+
+.section {
+  padding: 60px 0;
+}
+
+.cards {
+  list-style: none;
+  display: grid;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.cards li {
+  background: rgba(255, 255, 255, 0.05);
+  padding: 15px;
+}
+
+/* Arabic support */
+body[dir="rtl"] {
+  direction: rtl;
+}
+
+body[dir="rtl"] .nav-links {
+  flex-direction: row-reverse;
+}


### PR DESCRIPTION
## Summary
- Create `crazy-portfolio` with single-page portfolio for Moaz
- Add GSAP-powered animations and floating shapes
- Implement Arabic/English toggle with about, certificates, and projects sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae54f30f4c83299b360ba02f1d35e7